### PR TITLE
`deps`: bump dependencies; 2021 edition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "localzone"
 version = "0.2.0"
-edition = "2018"
+edition = "2021"
 authors = ["Armin Ronacher <armin.ronacher@active-4.com>"]
 license = "Apache-2.0"
 description = "figures out the local timezone as IANA / Olson identifier "
@@ -20,10 +20,10 @@ win_zones = []
 auto_validation = ["chrono-tz"]
 
 [dependencies]
-chrono-tz = { version = "0.6.0", optional = true }
+chrono-tz = { version = "0.8.6", optional = true }
 
 [target.'cfg(windows)'.dependencies]
-windows = { version = "0.28.0", features = ["Win32_Foundation", "Win32_System_Time"] }
+windows = { version = "0.54.0", features = ["Win32_Foundation", "Win32_System_Time"] }
 
 [target.wasm32-unknown-unknown.dependencies]
-js-sys = "0.3.55"
+js-sys = "0.3.69"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ win_zones = []
 auto_validation = ["chrono-tz"]
 
 [dependencies]
-chrono-tz = { version = "0.8.6", optional = true }
+chrono-tz = { version = "0.9", optional = true }
 
 [target.'cfg(windows)'.dependencies]
 windows = { version = "0.54.0", features = ["Win32_Foundation", "Win32_System_Time"] }


### PR DESCRIPTION
Hi @mitsuhiko ,
This crate is quite useful and allowed me to get the local tz in a x-platform way that chrono still does not provide even though the last commit was 3 years ago.
Hope this gets merged, or if you know a better way to get local tz today without this crate, if you can provide a hint :)
Thanks!

