### PR TITLE
Compatibility for macos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 Cargo.lock
+.vscode

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,0 @@
-{
-    "python.formatting.provider": "black",
-    "rust-analyzer.cargo.allFeatures": true
-}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,3 +27,7 @@ windows = { version = "0.54.0", features = ["Win32_Foundation", "Win32_System_Ti
 
 [target.wasm32-unknown-unknown.dependencies]
 js-sys = "0.3.69"
+
+[[example]]
+name = "demo"
+path = "examples/demo.rs"

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,8 @@
 all: test format-check lint
 
+demo:
+	cargo run --example demo --features chrono-tz
+
 test:
 	@cargo test
 	@cargo test --all-features
@@ -16,4 +19,4 @@ lint:
 	@rustup component add clippy 2> /dev/null
 	@cargo clippy
 
-.PHONY: all test format format-check lint
+.PHONY: all test format format-check lint demo

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -1,4 +1,4 @@
-use std::{env, fs};
+use std::{env, fs, process::Command};
 
 fn might_be_unix_tz(name: &str) -> bool {
     !name.is_empty()
@@ -55,6 +55,15 @@ pub fn get_local_zone<F: FnMut(&str) -> bool>(mut is_valid: F) -> Option<String>
             if validate(tz) {
                 return Some(tz.into());
             }
+        }
+    }
+
+    // Running $data "+%Z" returns the timezone not the exact local
+    if let Ok(output) = Command::new("sh").arg("-c").arg("date \"+%Z\"").output() {
+        let tz = String::from_utf8(output.stdout).unwrap_or("".to_string());
+        let tz = tz.trim();
+        if !tz.is_empty() && validate(tz) {
+            return Some(tz.to_string());
         }
     }
 

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -56,6 +56,15 @@ pub fn get_local_zone<F: FnMut(&str) -> bool>(mut is_valid: F) -> Option<String>
                 return Some(tz.into());
             }
         }
+
+        #[cfg(target_os = "macos")]
+        {
+            if let Some((_, tz)) = link.split_once("/zoneinfo.default/") {
+                if validate(tz) {
+                    return Some(tz.into());
+                }
+            }
+        }
     }
 
     // Running $data "+%Z" returns the timezone not the exact local


### PR DESCRIPTION
# macOS Compatibility Issues in Timezone Library

The current implementation exhibits compatibility challenges on macOS due to reliance on non-existent system paths. Notably, modern macOS versions structure timezone data under paths containing `/zoneinfo.default/`, whereas the library erroneously targets `/zoneinfo/`. Resolving this requires updating path-splitting logic to accommodate the macOS-specific directory structure.

# Fallback Mechanism Limitations
When primary methods fail, the library attempts to infer the timezone via the system’s UTC offset. While functional, this approach may yield imprecise results. For example:

- A system configured for `Europe/Berlin` (which observes `CET/CEST` daylight saving transitions) might incorrectly resolve to the generic CET identifier.

This fallback lacks granularity, as UTC offsets alone cannot reliably distinguish between regions with identical offsets but differing daylight saving rules or historical timezone data.